### PR TITLE
Update hybrid-cloud-support-bundle-no-deps.sh

### DIFF
--- a/hybrid-cloud-support-bundle/hybrid-cloud-support-bundle-no-deps.sh
+++ b/hybrid-cloud-support-bundle/hybrid-cloud-support-bundle-no-deps.sh
@@ -48,6 +48,8 @@ done
 mkdir -p "$output_dir/logs"
 kubectl -n "$namespace" get pods -o name | cut -d '/' -f 2 | tr '\n' '\0' | xargs -S1024 -0 -n1 -I {} sh -c "kubectl -n $namespace logs {} --all-containers > $output_dir/logs/{}.log"
 echo -n '.'
+
+# Try to get previous logs, but don't error out if not found
 kubectl -n "$namespace" get pods -o name | cut -d '/' -f 2 | tr '\n' '\0' | xargs -S1024 -0 -n1 -I {} sh -c "kubectl -n $namespace logs {} --all-containers --previous > $output_dir/logs/{}.previous.log || true"
 echo -n '.'
 


### PR DESCRIPTION
The previous command tries to get logs from a previously terminated instance of a container, but if the container hasn't crashed or been restarted, there are no "previous" logs available, leading to the error the customer was seeing.