### PR TITLE
Support Bundle: fix sed call and escape API key

### DIFF
--- a/hybrid-cloud-support-bundle/hybrid-cloud-support-bundle-no-deps.sh
+++ b/hybrid-cloud-support-bundle/hybrid-cloud-support-bundle-no-deps.sh
@@ -164,8 +164,10 @@ for pod in $(kubectl -n "$namespace" get pods -l app=qdrant -o name 2>> "${outpu
 
     set +x
     if [ -n "$api_key" ]; then
-        sed -i "s/${api_key}/*****/g" "$output_dir/output.log"
-        sed -i "s/${api_key}/*****/g" "$output_dir/trace.log"
+        # Escape special characters in the API key
+        escaped_api_key=$(printf '%s\n' "$api_key" | sed 's/[]\/$*.^[]/\\&/g')
+        sed -i -e "s|${escaped_api_key}|*****|g" "$output_dir/output.log"
+        sed -i -e "s|${escaped_api_key}|*****|g" "$output_dir/trace.log"
     fi
     set -x
 

--- a/hybrid-cloud-support-bundle/hybrid-cloud-support-bundle.sh
+++ b/hybrid-cloud-support-bundle/hybrid-cloud-support-bundle.sh
@@ -174,8 +174,10 @@ for pod in $(kubectl -n "$namespace" get pods -l app=qdrant -o name 2>> "${outpu
 
     set +x
     if [ -n "$api_key" ]; then
-        sed -i "s/${api_key}/*****/g" "$output_dir/output.log"
-        sed -i "s/${api_key}/*****/g" "$output_dir/trace.log"
+        # Escape special characters in the API key
+        escaped_api_key=$(printf '%s\n' "$api_key" | sed 's/[]\/$*.^[]/\\&/g')
+        sed -i -e "s|${escaped_api_key}|*****|g" "$output_dir/output.log"
+        sed -i -e "s|${escaped_api_key}|*****|g" "$output_dir/trace.log"
     fi
     set -x
 


### PR DESCRIPTION
The issue is with BSD version of `sed`

More info: https://stackoverflow.com/questions/33906892/using-sed-i-mac-osx-without-a-backup-file

Closes #18 

