### PR TITLE
Collect pdb and new endpoints

### DIFF
--- a/support-bundle/README.md
+++ b/support-bundle/README.md
@@ -63,6 +63,7 @@ chmod +x support-bundle.sh
   * Collection configuration endpoint
   * Collection cluster information endpoint
   * Collection optimizations endpoint
+  * Slow requests profiler endpoint
 * Network Connectivity between pods in the Qdrant namespace
 
 The support bundle does not contain any user data stored int the Qdrant database, on volumes or snapshots, or sensitive information like API keys or certificates.

--- a/support-bundle/README.md
+++ b/support-bundle/README.md
@@ -52,6 +52,7 @@ chmod +x support-bundle.sh
   * VolumeSnapshots.snapshot.storage.k8s.io
   * VolumeSnapshotClasses.snapshot.storage.k8s.io
   * PersistentVolumeClaims
+  * PodDisruptionBudgets.policy
 * Logs from all pods in the Qdrant namespace
 * Kubernetes version
 * Results of the Kubernetes metrics API for all nodes and pods in the Qdrant namespace, if available

--- a/support-bundle/README.md
+++ b/support-bundle/README.md
@@ -62,6 +62,7 @@ chmod +x support-bundle.sh
   * Collection list endpoint
   * Collection configuration endpoint
   * Collection cluster information endpoint
+  * Collection optimizations endpoint
 * Network Connectivity between pods in the Qdrant namespace
 
 The support bundle does not contain any user data stored int the Qdrant database, on volumes or snapshots, or sensitive information like API keys or certificates.

--- a/support-bundle/support-bundle.sh
+++ b/support-bundle/support-bundle.sh
@@ -163,6 +163,8 @@ for pod in $(kubectl -n "$namespace" get pods -l app=qdrant -o name 2>> "${outpu
     echo -n '.'
     curl -v "${args[@]}" "$protocol://localhost:6333/cluster" 2>> "${output_log}" | jq '.' > "$output_dir/qdrant-telemetry/$(basename $pod)-cluster.json"
     echo -n '.'
+    curl -v "${args[@]}" "$protocol://localhost:6333/profiler/slow_requests" 2>> "${output_log}" | jq '.' > "$output_dir/qdrant-telemetry/$(basename $pod)-slow-requests.json"
+    echo -n '.'
     collections=$(curl -v "${args[@]}" "$protocol://localhost:6333/collections" 2>> "${output_log}" | jq -r '.result.collections[] | .name')
     echo -n '.'
     for collection in $collections; do

--- a/support-bundle/support-bundle.sh
+++ b/support-bundle/support-bundle.sh
@@ -61,7 +61,7 @@ echo ""
 echo "Getting Kubernetes resources"
 
 # Get all Qdrant related resources in the namespace into indivdual files
-crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "deployment.apps" "statefulset.apps" "service" "configmap" "ingress.networking.k8s.io" "node" "storageclass.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshotclass.snapshot.storage.k8s.io" "volumesnapshot.snapshot.storage.k8s.io")
+crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "deployment.apps" "statefulset.apps" "service" "configmap" "ingress.networking.k8s.io" "node" "storageclass.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshotclass.snapshot.storage.k8s.io" "volumesnapshot.snapshot.storage.k8s.io" "poddisruptionbudget.policy")
 
 for crd in "${crds[@]}"; do
     mkdir -p "$output_dir/resources/$crd"

--- a/support-bundle/support-bundle.sh
+++ b/support-bundle/support-bundle.sh
@@ -170,6 +170,8 @@ for pod in $(kubectl -n "$namespace" get pods -l app=qdrant -o name 2>> "${outpu
         echo -n '.'
         curl -v "${args[@]}" "$protocol://localhost:6333/collections/$collection/cluster" 2>> "${output_log}" | jq '.' > "$output_dir/qdrant-telemetry/$(basename $pod)-collection-$collection-cluster.json"
         echo -n '.'
+        curl -v "${args[@]}" "$protocol://localhost:6333/collections/$collection/optimizations" 2>> "${output_log}" | jq '.' > "$output_dir/qdrant-telemetry/$(basename $pod)-collection-$collection-optimizations.json"
+        echo -n '.'
     done
 
     set +x


### PR DESCRIPTION
## What's added

- **PodDisruptionBudgets** (`poddisruptionbudget.policy`) — added to the Kubernetes resource list; collected alongside other cluster resources in `resources/`

- **`/collections/{name}/optimizations`** — fetched per collection per Qdrant pod, saved as `qdrant-telemetry/<pod>-collection-<name>-optimizations.json`

- **`/profiler/slow_requests`** — fetched per Qdrant pod, saved as `qdrant-telemetry/<pod>-slow-requests.json`