### PR TITLE
feat/add optional cluster-specific filtering to support bundle

### DIFF
--- a/support-bundle/README.md
+++ b/support-bundle/README.md
@@ -30,6 +30,13 @@ chmod +x support-bundle.sh
 ./support-bundle.sh the-qdrant-namespace
 ```
 
+To collect data for a **specific Qdrant cluster only**, pass `--cluster-id`:
+```bash
+./support-bundle.sh the-qdrant-namespace --cluster-id=your-cluster-id
+```
+
+This is useful when only one of multiple Qdrant clusters in the namespace is affected. Infra-level resources (nodes, storage classes, etc.) are always collected regardless of the filter.
+
 ## Collected data
 
 * YAML definitions of `kubectl describe` output including events and status of the following resources in the Qdrant namespace:

--- a/support-bundle/support-bundle-no-deps.sh
+++ b/support-bundle/support-bundle-no-deps.sh
@@ -38,9 +38,14 @@ if [ -z "$namespace" ]; then
 fi;
 
 qdrant_only="false"
-if [ "$2" = "--qdrant-only" ]; then
-    qdrant_only="true"
-fi
+cluster_id_filter=""
+for arg in "${@:2}"; do
+    if [ "$arg" = "--qdrant-only" ]; then
+        qdrant_only="true"
+    elif [[ "$arg" == --cluster-id=* ]]; then
+        cluster_id_filter="${arg#--cluster-id=}"
+    fi
+done
 
 # Check if the namespace exists
 if ! kubectl get namespace "$namespace" &> /dev/null; then
@@ -58,7 +63,11 @@ BASH_XTRACEFD="5"
 PS4='$LINENO: '
 set -x
 
-echo "Creating Qdrant Cloud support bundle for namespace ${namespace}"
+if [ -n "$cluster_id_filter" ]; then
+    echo "Creating Qdrant Cloud support bundle for namespace ${namespace}, Qdrant cluster ${cluster_id_filter}"
+else
+    echo "Creating Qdrant Cloud support bundle for namespace ${namespace}"
+fi
 
 echo ""
 echo "Getting nodes running Qdrant pods"
@@ -73,16 +82,38 @@ fi
 echo ""
 echo "Getting Kubernetes resources"
 
-# Get all Qdrant related resources in the namespace into indivdual files
-crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "deployment.apps" "statefulset.apps" "service" "configmap" "ingress.networking.k8s.io" "storageclass.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshotclass.snapshot.storage.k8s.io" "volumesnapshot.snapshot.storage.k8s.io")
+# Infra-level resources - always fetch regardless of cluster filter
+infra_crds=("storageclass.storage.k8s.io" "volumesnapshotclass.snapshot.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io")
 
-for crd in "${crds[@]}"; do
+# Qdrant-cluster-scoped resources - filtered by cluster-id label if a filter is set
+cluster_crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "deployment.apps" "statefulset.apps" "service" "configmap" "ingress.networking.k8s.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshot.snapshot.storage.k8s.io")
+
+label_selector_args=()
+if [ -n "$cluster_id_filter" ]; then
+    label_selector_args=(-l "cluster-id=$cluster_id_filter")
+fi
+
+for crd in "${infra_crds[@]}"; do
     mkdir -p "$output_dir/resources/$crd"
     kubectl -n "$namespace" get "$crd" -o wide 2>> "${output_log}" > "$output_dir/resources/list_$crd.yaml" || true
     echo -n '.'
-    # if crd exists
     if kubectl get "$crd" &> /dev/null; then
         names=$(kubectl -n "$namespace" get "$crd" -o name)
+        for name in $names; do
+            kubectl -n "$namespace" get "$name" -o yaml 2>> "${output_log}" > "$output_dir/resources/$name.yaml" || true
+            echo -n '.'
+            kubectl -n "$namespace" describe "$name" 2>> "${output_log}" > "$output_dir/resources/$name.txt" || true
+            echo -n '.'
+        done
+    fi
+done
+
+for crd in "${cluster_crds[@]}"; do
+    mkdir -p "$output_dir/resources/$crd"
+    kubectl -n "$namespace" get "$crd" "${label_selector_args[@]}" -o wide 2>> "${output_log}" > "$output_dir/resources/list_$crd.yaml" || true
+    echo -n '.'
+    if kubectl get "$crd" &> /dev/null; then
+        names=$(kubectl -n "$namespace" get "$crd" "${label_selector_args[@]}" -o name)
         for name in $names; do
             kubectl -n "$namespace" get "$name" -o yaml 2>> "${output_log}" > "$output_dir/resources/$name.yaml" || true
             echo -n '.'
@@ -160,6 +191,11 @@ for pod in $(kubectl -n "$namespace" get pods -l app=qdrant -o name 2>> "${outpu
     fi
 
     cluster_id=$(kubectl -n "$namespace" get pod "$pod_name" -o jsonpath='{.metadata.labels.cluster-id}' 2>> "${output_log}")
+
+    if [ -n "$cluster_id_filter" ] && [ "$cluster_id" != "$cluster_id_filter" ]; then
+        continue
+    fi
+
     cluster_name="qdrant-$cluster_id"
 
     # get secret reference from pod environment variable

--- a/support-bundle/support-bundle-no-deps.sh
+++ b/support-bundle/support-bundle-no-deps.sh
@@ -83,10 +83,11 @@ echo ""
 echo "Getting Kubernetes resources"
 
 # Infra-level resources - always fetch regardless of cluster filter
-infra_crds=("storageclass.storage.k8s.io" "volumesnapshotclass.snapshot.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io")
+# Includes resources without cluster-id label (deployment.apps, service) so they are never empty when filtering
+infra_crds=("storageclass.storage.k8s.io" "volumesnapshotclass.snapshot.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io" "deployment.apps" "service")
 
 # Qdrant-cluster-scoped resources - filtered by cluster-id label if a filter is set
-cluster_crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "deployment.apps" "statefulset.apps" "service" "configmap" "ingress.networking.k8s.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshot.snapshot.storage.k8s.io")
+cluster_crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "statefulset.apps" "configmap" "ingress.networking.k8s.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshot.snapshot.storage.k8s.io")
 
 label_selector_args=()
 if [ -n "$cluster_id_filter" ]; then

--- a/support-bundle/support-bundle.sh
+++ b/support-bundle/support-bundle.sh
@@ -40,9 +40,14 @@ if [ -z "$namespace" ]; then
 fi;
 
 qdrant_only="false"
-if [ "$2" = "--qdrant-only" ]; then
-    qdrant_only="true"
-fi
+cluster_id_filter=""
+for arg in "${@:2}"; do
+    if [ "$arg" = "--qdrant-only" ]; then
+        qdrant_only="true"
+    elif [[ "$arg" == --cluster-id=* ]]; then
+        cluster_id_filter="${arg#--cluster-id=}"
+    fi
+done
 
 # Check if the namespace exists
 if ! kubectl get namespace "$namespace" &> /dev/null; then
@@ -60,7 +65,11 @@ BASH_XTRACEFD="5"
 PS4='$LINENO: '
 set -x
 
-echo "Creating Qdrant Cloud support bundle for namespace ${namespace}"
+if [ -n "$cluster_id_filter" ]; then
+    echo "Creating Qdrant Cloud support bundle for namespace ${namespace}, Qdrant cluster ${cluster_id_filter}"
+else
+    echo "Creating Qdrant Cloud support bundle for namespace ${namespace}"
+fi
 
 echo ""
 echo "Getting nodes running Qdrant pods"
@@ -75,16 +84,38 @@ fi
 echo ""
 echo "Getting Kubernetes resources"
 
-# Get all Qdrant related resources in the namespace into indivdual files
-crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "deployment.apps" "statefulset.apps" "service" "configmap" "ingress.networking.k8s.io" "storageclass.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshotclass.snapshot.storage.k8s.io" "volumesnapshot.snapshot.storage.k8s.io" "poddisruptionbudget.policy")
+# Infra-level resources - always fetch regardless of cluster filter
+infra_crds=("storageclass.storage.k8s.io" "volumesnapshotclass.snapshot.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io")
 
-for crd in "${crds[@]}"; do
+# Qdrant-cluster-scoped resources - filtered by cluster-id label if a filter is set
+cluster_crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "deployment.apps" "statefulset.apps" "service" "configmap" "ingress.networking.k8s.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshot.snapshot.storage.k8s.io" "poddisruptionbudget.policy")
+
+label_selector_args=()
+if [ -n "$cluster_id_filter" ]; then
+    label_selector_args=(-l "cluster-id=$cluster_id_filter")
+fi
+
+for crd in "${infra_crds[@]}"; do
     mkdir -p "$output_dir/resources/$crd"
     kubectl -n "$namespace" get "$crd" -o wide 2>> "${output_log}" > "$output_dir/resources/list_$crd.yaml" || true
     echo -n '.'
-    # if crd exists
     if kubectl get "$crd" &> /dev/null; then
         names=$(kubectl -n "$namespace" get "$crd" -o name)
+        for name in $names; do
+            kubectl -n "$namespace" get "$name" -o yaml 2>> "${output_log}" > "$output_dir/resources/$name.yaml" || true
+            echo -n '.'
+            kubectl -n "$namespace" describe "$name" 2>> "${output_log}" > "$output_dir/resources/$name.txt" || true
+            echo -n '.'
+        done
+    fi
+done
+
+for crd in "${cluster_crds[@]}"; do
+    mkdir -p "$output_dir/resources/$crd"
+    kubectl -n "$namespace" get "$crd" "${label_selector_args[@]}" -o wide 2>> "${output_log}" > "$output_dir/resources/list_$crd.yaml" || true
+    echo -n '.'
+    if kubectl get "$crd" &> /dev/null; then
+        names=$(kubectl -n "$namespace" get "$crd" "${label_selector_args[@]}" -o name)
         for name in $names; do
             kubectl -n "$namespace" get "$name" -o yaml 2>> "${output_log}" > "$output_dir/resources/$name.yaml" || true
             echo -n '.'
@@ -162,6 +193,11 @@ for pod in $(kubectl -n "$namespace" get pods -l app=qdrant -o name 2>> "${outpu
     fi
 
     cluster_id=$(kubectl -n "$namespace" get pod "$pod_name" -o jsonpath='{.metadata.labels.cluster-id}' 2>> "${output_log}")
+
+    if [ -n "$cluster_id_filter" ] && [ "$cluster_id" != "$cluster_id_filter" ]; then
+        continue
+    fi
+
     cluster_name="qdrant-$cluster_id"
 
     # get secret reference from pod environment variable

--- a/support-bundle/support-bundle.sh
+++ b/support-bundle/support-bundle.sh
@@ -85,10 +85,11 @@ echo ""
 echo "Getting Kubernetes resources"
 
 # Infra-level resources - always fetch regardless of cluster filter
-infra_crds=("storageclass.storage.k8s.io" "volumesnapshotclass.snapshot.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io")
+# Includes resources without cluster-id label (deployment.apps, service) so they are never empty when filtering
+infra_crds=("storageclass.storage.k8s.io" "volumesnapshotclass.snapshot.storage.k8s.io" "helmrelease.cd.qdrant.io" "helmrepository.cd.qdrant.io" "helmchart.cd.qdrant.io" "deployment.apps" "service")
 
 # Qdrant-cluster-scoped resources - filtered by cluster-id label if a filter is set
-cluster_crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "deployment.apps" "statefulset.apps" "service" "configmap" "ingress.networking.k8s.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshot.snapshot.storage.k8s.io" "poddisruptionbudget.policy")
+cluster_crds=("qdrantcluster.qdrant.io" "qdrantclustersnapshot.qdrant.io" "qdrantclusterscheduledsnapshot.qdrant.io" "qdrantclusterrestore.qdrant.io" "pod" "statefulset.apps" "configmap" "ingress.networking.k8s.io" "networkpolicy.networking.k8s.io" "persistentvolumeclaim" "volumesnapshot.snapshot.storage.k8s.io" "poddisruptionbudget.policy")
 
 label_selector_args=()
 if [ -n "$cluster_id_filter" ]; then


### PR DESCRIPTION
### feat: Add optional cluster-specific filtering to support bundle

  ---
  Description:

  ## Problem

  When a Kubernetes namespace contains multiple Qdrant clusters, the support
  bundle script collects data for all of them — even if only one cluster is
  affected. This wastes significant time on telemetry port-forwards and
  resource fetches for unrelated clusters.

  ## Solution

  Add an optional `--cluster-id=<id>` flag to both `support-bundle.sh` and
  `support-bundle-no-deps.sh` to scope the bundle to a specific Qdrant cluster.

  ./support-bundle.sh <namespace> --cluster-id=<your-cluster-id>


  ## What changes
  
  - **Cluster-scoped resources** (pods, statefulsets, configmaps, services,
    PVCs, snapshots, etc.) are filtered using `-l cluster-id=<id>` when the
    flag is provided
  - **Telemetry port-forwards** are skipped for all pods not belonging to
    the specified cluster
  - **Infra-level resources** (nodes, storageclasses, helm resources,
    volumesnapshotclasses) are always collected in full — issues often
    lie in the customer's infra
  - **All pod logs** in the namespace are always collected in full so that
    operator/controller logs remain available for investigation
  - No change in behaviour when `--cluster-id` is not passed (fully
    backwards compatible)

 